### PR TITLE
Fixed plugin incompatibility

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/events/entity/DeathEvent.java
+++ b/src/main/java/uk/antiperson/stackmob/events/entity/DeathEvent.java
@@ -23,7 +23,7 @@ public class DeathEvent implements Listener {
         this.sm = sm;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onDeath(EntityDeathEvent e) {
         Entity dead = e.getEntity();
 


### PR DESCRIPTION
According to [TheIronMinerLv's post](https://www.spigotmc.org/threads/stackmob.184178/page-51#post-2822621) on SpigotMC, the plugin does not multiply drops set by other plugins accordingly. This is because StackMob's EntityDeathEvent is fired before other plugins (The EventPriority is set to LOWEST).

