### PR TITLE
Add ability to update tag

### DIFF
--- a/src/main/java/uk/antiperson/stackmob/StackMob.java
+++ b/src/main/java/uk/antiperson/stackmob/StackMob.java
@@ -138,7 +138,7 @@ public class StackMob extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new UnloadEvent(this), this);
         getCommand("sm").setExecutor(new Commands(this));
         new StackTask(this).runTaskTimer(this, 0, config.getCustomConfig().getInt("task-delay"));
-        new TagTask(this).runTaskTimer(this, 0, 5);
+        new TagTask(this).runTaskTimer(this, 0, config.getCustomConfig().getInt("tag-update"));
     }
 
     private void registerNotEssentialEvents(){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,6 +41,8 @@ custom:
 
 # The delay between each time the stacking task is ran (in ticks.)
 task-delay: 100
+# The time to update the Stacking tag
+tag-update: 5
 # The maximum size a single stack can be.
 stack-max: 20
 # If bigger stacks should get priority when stacking on the task.


### PR DESCRIPTION
During my time using this plugin, I found out that tag update is pretty inefficient.
https://timings.aikar.co/?id=9311d739fc664ce7923b7372a127df1b

I decided to do something about the plugin, for the meantime, it should be able the delay between each update in the mob tag to prevent serious lag causing from the scheduler.